### PR TITLE
fix: css微修正

### DIFF
--- a/app/assets/stylesheets/results.scss
+++ b/app/assets/stylesheets/results.scss
@@ -44,7 +44,8 @@
   width: 40%;
   padding: 6rem;
   background-color: rgba(255,255,255,0.7);
-  text-align: left;
+  text-align: justify;
+  line-height: 1.5;
   overflow: auto;
   @media (max-width: 425px) {
     width: 100%;

--- a/app/views/results/results.html.slim
+++ b/app/views/results/results.html.slim
@@ -7,11 +7,10 @@
         - if (island.tags.pluck(:name) & session[:answer]).count >= 3
           - count += 1
           .island-image
-            / = image_tag island.image, width: '100%', height: '100%', alt: "#{island.name}の画像"
             - if island.image.attached?
               = image_tag island.image, width: '100%', height: '100%', alt: "#{island.name}の画像"
             - else
-              = image_tag 'bg_image.jpeg', width: '100%', height: '100%', alt: "#{island.name}の画像"
+              = image_tag 'bg_image.jpeg', width: '100%', height: '100%'
           .island-introduce
             .island-location
               h2.island-name


### PR DESCRIPTION
## 概要
- 島の説明文の部分のcssを修正
- 島の画像がなかった場合のデフォルト画像のalt属性を削除
