### PR TITLE
add: gem meta-tagsを導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,4 +60,5 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'slim-rails'
 gem 'seed-fu'
 gem 'dotenv-rails'
-gem "aws-sdk-s3", require: false
+gem 'aws-sdk-s3', require: false
+gem 'meta-tags'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,6 +134,8 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (1.0.1)
+    meta-tags (2.16.0)
+      actionpack (>= 3.2.0, < 7.1)
     method_source (1.0.0)
     mini_mime (1.1.1)
     minitest (5.14.4)
@@ -324,6 +326,7 @@ DEPENDENCIES
   html2slim
   jbuilder (~> 2.7)
   listen (~> 3.2)
+  meta-tags
   mysql2 (>= 0.4.4)
   pry-byebug
   pry-rails

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,31 @@
 module ApplicationHelper
+  def default_meta_tags
+    {
+      site: 'シマサガシ',
+      title: 'シマサガシ あなたにおすすめの「島」を提案するサービス',
+      reverse: true,
+      separator: '|',
+      description: '旅行先を考える際に「島」という選択肢を提案するサービスです。簡単な質問に答えるだけであなたにオススメの島を診断します。',
+      keywords: '旅行, 国内, 一人旅, 島',
+      canonical: request.original_url,
+      noindex: ! Rails.env.production?,
+      icon: [
+        { href: image_url('favicon.ico') },
+        # { href: image_url('icon.jpg'), rel: 'apple-touch-icon', sizes: '180x180', type: 'image/jpg' },
+      ],
+      og: {
+        site_name: 'シマサガシ',
+        title: 'あなたにおすすめの「島」を提案するサービス',
+        description: '旅行先を考える際に「島」という選択肢を提案するサービスです。簡単な質問に答えるだけであなたにオススメの島を診断します。',
+        type: 'website',
+        url: request.original_url,
+        image: image_url('logos/logo-name-white.png'),
+        locale: 'ja_JP',
+      },
+      twitter: {
+        card: 'summary_large_image',
+        site: '@tanakadessssu',
+      }
+    }
+  end
 end

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -9,6 +9,7 @@ html lang='ja'
     link[rel="preconnect" href="https://fonts.googleapis.com"]
     link[rel="preconnect" href="https://fonts.gstatic.com" crossorigin=""]
     link[href="https://fonts.googleapis.com/css2?family=Kosugi&display=swap" rel="stylesheet"]
+    = display_meta_tags(default_meta_tags)
     = favicon_link_tag 'favicon.ico'
     = csrf_meta_tags
     = csp_meta_tag

--- a/app/views/questions/shindan1.html.slim
+++ b/app/views/questions/shindan1.html.slim
@@ -1,3 +1,4 @@
+- set_meta_tags noindex: true
 .content-wrapper
   .question-wrapper
     .question-card

--- a/app/views/questions/shindan2.html.slim
+++ b/app/views/questions/shindan2.html.slim
@@ -1,3 +1,4 @@
+- set_meta_tags noindex: true
 .content-wrapper
   .question-card
     .choices

--- a/app/views/questions/shindan3.html.slim
+++ b/app/views/questions/shindan3.html.slim
@@ -1,3 +1,4 @@
+- set_meta_tags noindex: true
 .content-wrapper
   .question-card
     .choices

--- a/app/views/questions/shindan4.html.slim
+++ b/app/views/questions/shindan4.html.slim
@@ -1,3 +1,4 @@
+- set_meta_tags noindex: true
 .content-wrapper
   .question-card
     .choices

--- a/app/views/questions/shindan5.html.slim
+++ b/app/views/questions/shindan5.html.slim
@@ -1,3 +1,4 @@
+- set_meta_tags noindex: true
 .content-wrapper
   .question-card
     .choices

--- a/app/views/results/results.html.slim
+++ b/app/views/results/results.html.slim
@@ -1,3 +1,4 @@
+- set_meta_tags noindex: true
 .result-wrapper
   h3 あなたにおすすめの島は…
   .result-area

--- a/config/initializers/meta_tags.rb
+++ b/config/initializers/meta_tags.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Use this setup block to configure all options available in MetaTags.
+MetaTags.configure do |config|
+  # How many characters should the title meta tag have at most. Default is 70.
+  # Set to nil or 0 to remove limits.
+  # config.title_limit = 70
+
+  # When true, site title will be truncated instead of title. Default is false.
+  # config.truncate_site_title_first = false
+
+  # Maximum length of the page description. Default is 300.
+  # Set to nil or 0 to remove limits.
+  # config.description_limit = 300
+
+  # Maximum length of the keywords meta tag. Default is 255.
+  # config.keywords_limit = 255
+
+  # Default separator for keywords meta tag (used when an Array passed with
+  # the list of keywords). Default is ", ".
+  # config.keywords_separator = ', '
+
+  # When true, keywords will be converted to lowercase, otherwise they will
+  # appear on the page as is. Default is true.
+  # config.keywords_lowercase = true
+
+  # When true, the output will not include new line characters between meta tags.
+  # Default is false.
+  # config.minify_output = false
+
+  # When false, generated meta tags will be self-closing (<meta ... />) instead
+  # of open (`<meta ...>`). Default is true.
+  # config.open_meta_tags = true
+
+  # List of additional meta tags that should use "property" attribute instead
+  # of "name" attribute in <meta> tags.
+  # config.property_tags.push(
+  #   'x-hearthstone:deck',
+  # )
+end


### PR DESCRIPTION
## 概要
- gem 'meta-tags'を導入
- meta-tagsの設定
- application.html.slimにmeta-tags設置
- 診断ページ、結果ページにnoindex: true設定